### PR TITLE
V-76727 casted cookie timeout to integer so control won't fail incorrectly

### DIFF
--- a/controls/V-76727.rb
+++ b/controls/V-76727.rb
@@ -63,7 +63,7 @@ control 'V-76727' do
     it { should cmp 'UseCookies' }
   end
   describe 'The IIS web server cookie timeout limit' do
-    subject { cookie_timeout }
+    subject { cookie_timeout.to_i }
     it { should be <= 20 }
   end
 end


### PR DESCRIPTION
Signed-off-by: HackerShark <melsharkawi@mitre.org>